### PR TITLE
Separated coverage calculation to be NaN on ZeroDivisionError.

### DIFF
--- a/src/algorithms/gmm.py
+++ b/src/algorithms/gmm.py
@@ -370,8 +370,15 @@ def run_gmm_test(sc, sqlCtx, table_name, fields, model, where_clause=''):
     mean_error = np.mean(errors)
     print('Median Error', median_error)
     print('Mean Error: ', mean_error)
+
+    # calculate coverage
+    try:
+        coverage = len(errors)/float(num_vals)
+    except ZeroDivisionError:
+        coverage = np.nan
+
     # gather errors
-    final_results = {'median': median_error, 'mean': mean_error, 'coverage': len(errors)/float(num_vals),
+    final_results = {'median': median_error, 'mean': mean_error, 'coverage': coverage,
                      'num_locs': len(errors), 'fields': fields}
     return final_results
 


### PR DESCRIPTION
Sets coverage = NaN in the case where run_gmm_test throws a ZeroDivisionError, i.e. the coverage denominator num_vals (tweets w/ geo) is 0. 